### PR TITLE
Be more generous with spf failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Once you have correctly configured Mandrill, you can go ahead and delete this co
 
 [Adding Routes]: http://help.mandrill.com/entries/21699367-Inbound-Email-Processing-Overview
 
+#### Allowing domains without SPF configured
+Sometimes, due to circumstances outside our control, a domain may not have SPF set up. In those cases, you can set the adapter to pass results to your email processor.
+
+```
+Griddler::Mandrill::Adapter.allow_spf_none = true
+```
+
 ## Credits
 
 Griddler::Mandrill was extracted from Griddler by [Stafford Brunk](https://github.com/wingrunr21).

--- a/README.md
+++ b/README.md
@@ -38,10 +38,26 @@ Once you have correctly configured Mandrill, you can go ahead and delete this co
 [Adding Routes]: http://help.mandrill.com/entries/21699367-Inbound-Email-Processing-Overview
 
 #### Allowing domains without SPF configured
-Sometimes, due to circumstances outside our control, a domain may not have SPF set up. In those cases, you can set the adapter to pass results to your email processor.
+Sometimes, due to circumstances outside our control, a domain may not have SPF set up or configured incorrectly.
 
+If that is causing you to miss emails; you may configure the adapter to allow those results through to your applications email processor.
+
+Please see [RFC4408 Section 2.5](https://tools.ietf.org/html/rfc4408#section-2.5) to determine whether your particular use case conforms to the SPF standard.
 ```
-Griddler::Mandrill::Adapter.allow_spf_none = true
+# Allow messages from domains without SPF configured
+Griddler::Mandrill.spf_allow.add(:none)
+
+# Allow messages from domains where SPF is erroring temporarily
+Griddler::Mandrill.spf_allow.add(:temperror)
+
+# Allow messages from domains where SPF is erroring permanently
+Griddler::Mandrill.spf_allow.add(:permerror)
+
+# Allow messages from domains where SPF is soft-failing
+Griddler::Mandrill.spf_allow.add(:softfail)
+
+# Allow messages from domains where SPF is failing
+Griddler::Mandrill.spf_allow.add(:fail)
 ```
 
 ## Credits

--- a/lib/griddler/mandrill.rb
+++ b/lib/griddler/mandrill.rb
@@ -12,18 +12,5 @@ module Griddler
     def self.spf_allow
       @spf_allow ||= Set.new([:pass, :neutral])
     end
-
-    def self.allow_spf_none?
-      spf_allow.include?(:none)
-
-    end
-
-    def self.allow_spf_none=(allow_spf_none)
-      if allow_spf_none
-        spf_allow.add(:none)
-      else
-        spf_allow.delete(:none)
-      end
-    end
   end
 end

--- a/lib/griddler/mandrill.rb
+++ b/lib/griddler/mandrill.rb
@@ -1,6 +1,29 @@
 require 'griddler'
-require 'griddler/mandrill/version'
 require 'griddler/mandrill/adapter'
 require 'griddler/mandrill/logging'
+require 'griddler/mandrill/spf_filter'
+require 'griddler/mandrill/version'
 
 Griddler.adapter_registry.register(:mandrill, Griddler::Mandrill::Adapter)
+
+module Griddler
+  module Mandrill
+
+    def self.spf_allow
+      @spf_allow ||= Set.new([:pass, :neutral])
+    end
+
+    def self.allow_spf_none?
+      spf_allow.include?(:none)
+
+    end
+
+    def self.allow_spf_none=(allow_spf_none)
+      if allow_spf_none
+        spf_allow.add(:none)
+      else
+        spf_allow.delete(:none)
+      end
+    end
+  end
+end

--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -6,33 +6,15 @@ module Griddler
         @params = params
       end
 
-      def self.allow_spf_none?
-        @allow_spf_none || false
-      end
-
-      def allow_spf_none?
-        self.class.allow_spf_none?
-      end
-
-      def self.allow_spf_none=(allow_spf_none)
-        @allow_spf_none = allow_spf_none
-      end
-
       def self.normalize_params(params)
         adapter = new(params)
         adapter.normalize_params
       end
 
-      def event_passes_spf?(event)
-        event[:spf].present? &&
-          ((event[:spf][:result] == 'pass' || event[:spf][:result] == 'neutral') ||
-          (allow_spf_none? && event[:spf][:result] == 'none'))
-      end
-
       def normalize_params
         logger.debug(message: "entered #normalize_params", events: events)
         events.select do |event|
-          event_passes_spf?(event)
+          spf_filter.passes?(event)
         end.map do |event|
           {
             to: recipients(:to, event),
@@ -112,6 +94,10 @@ module Griddler
         tempfile.write(content)
         tempfile.rewind
         tempfile
+      end
+
+      def spf_filter
+        @spf_filter ||= SpfFilter.new
       end
     end
   end

--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -6,15 +6,33 @@ module Griddler
         @params = params
       end
 
+      def self.allow_spf_none?
+        @allow_spf_none || false
+      end
+
+      def allow_spf_none?
+        self.class.allow_spf_none?
+      end
+
+      def self.allow_spf_none=(allow_spf_none)
+        @allow_spf_none = allow_spf_none
+      end
+
       def self.normalize_params(params)
         adapter = new(params)
         adapter.normalize_params
       end
 
+      def event_passes_spf?(event)
+        event[:spf].present? &&
+          ((event[:spf][:result] == 'pass' || event[:spf][:result] == 'neutral') ||
+          (allow_spf_none? && event[:spf][:result] == 'none'))
+      end
+
       def normalize_params
         logger.debug(message: "entered #normalize_params", events: events)
         events.select do |event|
-          event[:spf].present? && (event[:spf][:result] == 'pass' || event[:spf][:result] == 'neutral')
+          event_passes_spf?(event)
         end.map do |event|
           {
             to: recipients(:to, event),

--- a/lib/griddler/mandrill/spf_filter.rb
+++ b/lib/griddler/mandrill/spf_filter.rb
@@ -1,0 +1,21 @@
+module Griddler
+  module Mandrill
+    # Checks whether an events SPF result matches the configured preferences
+    class SpfFilter
+      attr_accessor :allow
+      def initialize(allow: default_allow_options)
+        self.allow = allow
+      end
+
+      def passes?(event)
+        event[:spf].present? && allow.include?(event[:spf][:result].to_sym)
+      end
+
+      private
+
+      def default_allow_options
+        Griddler::Mandrill.spf_allow.dup
+      end
+    end
+  end
+end

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -118,6 +118,33 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
     end
   end
 
+  describe 'when the spf record is none' do
+    before do
+      @params = params_hash
+      @params.first[:msg][:spf] = { result: 'none', detail: '' }
+    end
+
+    it 'does not include the emails without spf results by default' do
+      params = default_params(@params)
+      normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+      expect(normalized_params).to be_empty
+    end
+
+    context 'when the adapter is configured to allow none' do
+      before do
+        Griddler::Mandrill::Adapter.allow_spf_none = true
+      end
+      after do
+        Griddler::Mandrill::Adapter.allow_spf_none = false
+      end
+      it 'includes the message' do
+        params = default_params(@params)
+        normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+        expect(normalized_params).not_to be_empty
+      end
+    end
+  end
+
   describe 'when the spf record is softfail' do
     before do
       @params = params_hash

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -132,10 +132,10 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
 
     context 'when the adapter is configured to allow none' do
       before do
-        Griddler::Mandrill.allow_spf_none = true
+        Griddler::Mandrill.spf_allow.add(:none)
       end
       after do
-        Griddler::Mandrill.allow_spf_none = false
+        Griddler::Mandrill.spf_allow.delete(:none)
       end
       it 'includes the message' do
         params = default_params(@params)

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -132,10 +132,10 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
 
     context 'when the adapter is configured to allow none' do
       before do
-        Griddler::Mandrill::Adapter.allow_spf_none = true
+        Griddler::Mandrill.allow_spf_none = true
       end
       after do
-        Griddler::Mandrill::Adapter.allow_spf_none = false
+        Griddler::Mandrill.allow_spf_none = false
       end
       it 'includes the message' do
         params = default_params(@params)
@@ -151,10 +151,79 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
       @params.first[:msg][:spf] = { result: 'softfail', detail: 'domain owner discourages use of this host' }
     end
 
-    it "doesn't include emails that have failed the SPF test" do
+    it "does not include the emails by default" do
       params = default_params(@params)
       normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
       expect(normalized_params).to be_empty
+    end
+
+    context 'when the adapter is configured to allow softfail' do
+      before do
+        Griddler::Mandrill.spf_allow.add(:softfail)
+      end
+      after do
+        Griddler::Mandrill.spf_allow.delete(:softfail)
+      end
+      it 'includes the message' do
+        params = default_params(@params)
+        normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+        expect(normalized_params).not_to be_empty
+      end
+    end
+  end
+
+  describe 'when the spf record is temperror' do
+    before do
+      @params = params_hash
+      @params.first[:msg][:spf] = { result: 'temperror', detail: 'sender SPF temperror' }
+    end
+
+    it "drops the email by default" do
+      params = default_params(@params)
+      normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+      expect(normalized_params).to be_empty
+    end
+
+    context 'when the adapter is configured to allow temperror' do
+      before do
+        Griddler::Mandrill.spf_allow.add(:temperror)
+      end
+      after do
+        Griddler::Mandrill.spf_allow.delete(:temperror)
+      end
+
+      it 'includes the message' do
+        params = default_params(@params)
+        normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+        expect(normalized_params).not_to be_empty
+      end
+    end
+  end
+
+  describe 'when the spf record is permerror' do
+    before do
+      @params = params_hash
+      @params.first[:msg][:spf] = { result: 'permerror', detail: 'sender SPF permerror' }
+    end
+
+    it "drops the email by default" do
+      params = default_params(@params)
+      normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+      expect(normalized_params).to be_empty
+    end
+
+    context 'when the adapter is configured to allow permerror' do
+      before do
+        Griddler::Mandrill.spf_allow.add(:permerror)
+      end
+      after do
+        Griddler::Mandrill.spf_allow.delete(:permerror)
+      end
+      it 'includes the message' do
+        params = default_params(@params)
+        normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+        expect(normalized_params).not_to be_empty
+      end
     end
   end
 
@@ -168,6 +237,20 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
       params = default_params(@params)
       normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
       expect(normalized_params).to be_empty
+    end
+
+    context 'when the adapter is configured to allow fail' do
+      before do
+        Griddler::Mandrill.spf_allow.add(:fail)
+      end
+      after do
+        Griddler::Mandrill.spf_allow.delete(:fail)
+      end
+      it 'includes the message' do
+        params = default_params(@params)
+        normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+        expect(normalized_params).not_to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
There appear to be several ways SPF fails where an application may want to
still receive those messages.

Please see [RFC4408 Section 2.5](https://tools.ietf.org/html/rfc4408#section-2.5) to determine whether your particular use case conforms to the SPF standard.